### PR TITLE
modified:   k8s/ingress/sq-ingress.yaml

### DIFF
--- a/k8s/ingress/sq-ingress.yaml
+++ b/k8s/ingress/sq-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: sq
@@ -12,6 +12,21 @@ spec:
     - host: dmeppiel.eu.ngrok.io
       http:
         paths:
-        - backend:
-            serviceName: ce-lts-sonarqube
-            servicePort: http
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: ce-lts-sonarqube
+              port:
+                name: http
+    # define below the local adress where the service can be reached, the one added to your /etc/hosts
+    - host: my.sonarqube.io
+      http:
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: ce-lts-sonarqube
+              port:
+                name: http


### PR DESCRIPTION
Update networking to v1 so that deprecation warnings are not showing anymore, and update the syntax accordingly.

Add a secondary ingress inbound routing to SonarQube for the local address to work (the address cannot be the same on ngrok and in /etc/hosts, as the former will take precedence once defined ngrok.io side)